### PR TITLE
Eliminate Costed typeclass

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -10,9 +10,9 @@ import Data.Ord
 -- | Compare with the first function. In the event of a tiebreak, compare with the next.
 -- | I expect there's a built-in for this, but I can't find it.
 tiebreak :: (a -> a -> Ordering) -> (a -> a -> Ordering) -> a -> a -> Ordering
-tiebreak f g a b
-  | f a b == EQ = g a b
-  | otherwise = f a b
+tiebreak f g a b = case f a b of
+                     EQ -> g a b
+                     o  -> o
 
 ------------------------------------------------------------
 -- The knapsack algorithm

--- a/Main.hs
+++ b/Main.hs
@@ -21,9 +21,6 @@ tiebreak f g a b = case f a b of
 totalCost :: (Num b, Ord b) => (a -> b) -> [a] -> b
 totalCost cost = sum . fmap cost
 
-costWithin :: Ord b => (a -> b) -> b -> a -> Bool
-costWithin cost w a = w >= cost a
-
 largestSolution :: (Num b, Ord b) => (a -> b) -> [[a]] -> [a]
 largestSolution _ [] = []
 largestSolution cost is = maximumBy (tiebreak (comparing (totalCost cost)) (flip (comparing length))) is
@@ -33,7 +30,7 @@ knapsack :: (Num b, Ord b) => (a -> b) -> (a -> [a] -> [a]) -> b -> [a] -> [a]
 knapsack _ _ 0 _  = []
 knapsack _ _ _ [] = []
 knapsack cost prune w xs = largestSolution cost possibleSolutions
-  where validItems = filter (costWithin cost w) xs
+  where validItems = filter ((<= w) . cost) xs
         possibleSolutions = fmap knapsackWithout validItems
         knapsackWithout i = i : knapsack cost prune (w - cost i) (prune i validItems)
 

--- a/Main.hs
+++ b/Main.hs
@@ -18,20 +18,20 @@ tiebreak f g a b
 -- The knapsack algorithm
 ------------------------------------------------------------
 
-type Cost a = a -> Integer
+type Cost a b = a -> b
 
-totalCost :: Cost a -> [a] -> Integer
+totalCost :: (Num b, Ord b) => Cost a b -> [a] -> b
 totalCost cost = sum . fmap cost
 
-costWithin :: Cost a -> Integer -> a -> Bool
+costWithin :: Ord b => Cost a b -> b -> a -> Bool
 costWithin cost w a = w >= cost a
 
-largestSolution :: Cost a -> [[a]] -> [a]
+largestSolution :: (Num b, Ord b) => Cost a b -> [[a]] -> [a]
 largestSolution _ [] = []
 largestSolution cost is = maximumBy (tiebreak (comparing (totalCost cost)) (flip (comparing length))) is
 
 -- TODO : Memoize.
-knapsack :: Cost a -> (a -> [a] -> [a]) -> Integer -> [a] -> [a]
+knapsack :: (Num b, Ord b) => Cost a b -> (a -> [a] -> [a]) -> b -> [a] -> [a]
 knapsack _ _ 0 _  = []
 knapsack _ _ _ [] = []
 knapsack cost prune w xs = largestSolution cost possibleSolutions
@@ -40,11 +40,11 @@ knapsack cost prune w xs = largestSolution cost possibleSolutions
         knapsackWithout i = i : knapsack cost prune (w - cost i) (prune i validItems)
 
 -- | Unbounded Knapsack. There is an unlimited number of each item.
-uks :: Cost a -> Integer -> [a] -> [a]
+uks :: (Num b, Ord b) => Cost a b -> b -> [a] -> [a]
 uks cost = knapsack cost (flip const)
 
 -- | Bounded Knapsack. Items can only be consumed once.
-bks :: (Eq a) => Cost a -> Integer -> [a] -> [a]
+bks :: (Eq a, Num b, Ord b) => Cost a b -> b -> [a] -> [a]
 bks cost = knapsack cost delete
 
 ------------------------------------------------------------
@@ -54,7 +54,7 @@ bks cost = knapsack cost delete
 data Item = Item String Integer
               deriving (Read, Show, Eq)
 
-itemCost :: Cost Item
+itemCost :: Cost Item Integer
 itemCost (Item _ w) = w
 
 items :: [Item]

--- a/Main.hs
+++ b/Main.hs
@@ -18,20 +18,18 @@ tiebreak f g a b
 -- The knapsack algorithm
 ------------------------------------------------------------
 
-type Cost a b = a -> b
-
-totalCost :: (Num b, Ord b) => Cost a b -> [a] -> b
+totalCost :: (Num b, Ord b) => (a -> b) -> [a] -> b
 totalCost cost = sum . fmap cost
 
-costWithin :: Ord b => Cost a b -> b -> a -> Bool
+costWithin :: Ord b => (a -> b) -> b -> a -> Bool
 costWithin cost w a = w >= cost a
 
-largestSolution :: (Num b, Ord b) => Cost a b -> [[a]] -> [a]
+largestSolution :: (Num b, Ord b) => (a -> b) -> [[a]] -> [a]
 largestSolution _ [] = []
 largestSolution cost is = maximumBy (tiebreak (comparing (totalCost cost)) (flip (comparing length))) is
 
 -- TODO : Memoize.
-knapsack :: (Num b, Ord b) => Cost a b -> (a -> [a] -> [a]) -> b -> [a] -> [a]
+knapsack :: (Num b, Ord b) => (a -> b) -> (a -> [a] -> [a]) -> b -> [a] -> [a]
 knapsack _ _ 0 _  = []
 knapsack _ _ _ [] = []
 knapsack cost prune w xs = largestSolution cost possibleSolutions
@@ -40,11 +38,11 @@ knapsack cost prune w xs = largestSolution cost possibleSolutions
         knapsackWithout i = i : knapsack cost prune (w - cost i) (prune i validItems)
 
 -- | Unbounded Knapsack. There is an unlimited number of each item.
-uks :: (Num b, Ord b) => Cost a b -> b -> [a] -> [a]
+uks :: (Num b, Ord b) => (a -> b) -> b -> [a] -> [a]
 uks cost = knapsack cost (flip const)
 
 -- | Bounded Knapsack. Items can only be consumed once.
-bks :: (Eq a, Num b, Ord b) => Cost a b -> b -> [a] -> [a]
+bks :: (Eq a, Num b, Ord b) => (a -> b) -> b -> [a] -> [a]
 bks cost = knapsack cost delete
 
 ------------------------------------------------------------
@@ -54,7 +52,7 @@ bks cost = knapsack cost delete
 data Item = Item String Integer
               deriving (Read, Show, Eq)
 
-itemCost :: Cost Item Integer
+itemCost :: Item -> Integer
 itemCost (Item _ w) = w
 
 items :: [Item]


### PR DESCRIPTION
Imagine that songs have both prices and durations, so you might want to
knapsack them by duration into a time limit, or instead pack them by
price into a total budget.

Using a Costed typeclass for this, you're limited to a single instance
of Costed per module, which is a code smell. The solution is to simply
parameterise knapsack on the costing function, so that the Costed
typeclass becomes a regular type.
